### PR TITLE
VIVI-2930 Add socketFactory option to Server constructor

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -50,6 +50,7 @@ function Server (opts) {
   this.perMessageDeflate = false !== opts.perMessageDeflate ? (opts.perMessageDeflate || true) : false;
   this.httpCompression = false !== opts.httpCompression ? (opts.httpCompression || {}) : false;
   this.initialPacket = opts.initialPacket;
+  this.socketFactory = opts.socketFactory || defaultSocketFactory;
 
   var self = this;
 
@@ -312,7 +313,7 @@ Server.prototype.handshake = function (transportName, req) {
     sendErrorMessage(req, req.res, Server.errors.BAD_REQUEST);
     return;
   }
-  var socket = new Socket(id, this, transport, req);
+  var socket = this.socketFactory(id, this, transport, req);
   var self = this;
 
   if (false !== this.cookie) {
@@ -513,6 +514,21 @@ function abortConnection (socket, code) {
     );
   }
   socket.destroy();
+}
+
+/**
+ * Creates standard engine.io Socket
+ *
+ * @param {id} socket id
+ * @param {Server}
+ * @param {Transport}
+ * @param {http.IncomingMessage}
+ * @return {Socket}
+ * @api private
+ */
+
+function defaultSocketFactory(id, srv, transport, req) {
+  return new Socket(id, srv, transport, req);
 }
 
 /* eslint-disable */


### PR DESCRIPTION
### The kind of change this PR does introduce

* [ ] a bug fix
* [x] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour


### New behaviour
add factory function to Server opts to allow alternative Engine.io sockets to be injected.

### Other information (e.g. related issues)


